### PR TITLE
[squid:S1132] Strings literals should be placed on the left side when checking for equality

### DIFF
--- a/app/src/main/java/io/github/otakuchiyan/dnsman/DnsEditActivity.java
+++ b/app/src/main/java/io/github/otakuchiyan/dnsman/DnsEditActivity.java
@@ -75,7 +75,7 @@ public class DnsEditActivity extends Activity {
         dnsEntry[0] = dns1.getText().toString();
         dnsEntry[1] = dns2.getText().toString();
 
-        if(dnsEntry[0].equals("") && dnsEntry[1].equals("")){
+        if("".equals(dnsEntry[0]) && "".equals(dnsEntry[1])){
             Toast.makeText(this, R.string.toast_no_dns, Toast.LENGTH_SHORT).show();
             return;
         }

--- a/app/src/main/java/io/github/otakuchiyan/dnsman/DnsListActivity.java
+++ b/app/src/main/java/io/github/otakuchiyan/dnsman/DnsListActivity.java
@@ -142,7 +142,7 @@ public class DnsListActivity extends ListActivity {
             @Override
             public void onClick(DialogInterface dialog, int which) {
                 String dns = dnsEditText.getText().toString();
-                if (!dns.equals("") &&
+                if (!"".equals(dns) &&
                         (IPChecker.IPv4Checker(dns)
                                 || IPChecker.IPv6Checker(dns))) {
                     adapter.add(dns);
@@ -168,7 +168,7 @@ public class DnsListActivity extends ListActivity {
             @Override
             public void onClick(DialogInterface dialog, int which) {
                 String dns = dnsEditText.getText().toString();
-                if (!dns.equals("") &&
+                if (!"".equals(dns) &&
                         (IPChecker.IPv4Checker(dns)
                                 || IPChecker.IPv6Checker(dns))) {
                     adapter.add(dns);

--- a/app/src/main/java/io/github/otakuchiyan/dnsman/DnsVpnService.java
+++ b/app/src/main/java/io/github/otakuchiyan/dnsman/DnsVpnService.java
@@ -52,9 +52,9 @@ public class DnsVpnService extends VpnService implements ValueConstants{
                 Enumeration<InetAddress> addresses = ifaces.nextElement().getInetAddresses();
                 while (addresses.hasMoreElements()) {
                     String addr = addresses.nextElement().getHostAddress();
-                    if (!addr.equals("127.0.0.1") &&
-                            !addr.equals("0.0.0.0") &&
-                            !addr.equals("::1%1") &&
+                    if (!"127.0.0.1".equals(addr) &&
+                            !"0.0.0.0".equals(addr) &&
+                            !"::1%1".equals(addr) &&
                             //Escaping IPv6
                             addr.charAt(5) != ':') {
                         return addr;
@@ -87,7 +87,7 @@ public class DnsVpnService extends VpnService implements ValueConstants{
                     }
 
                     //If no suffix
-                    if (real_addr.equals("")) {
+                    if ("".equals(real_addr)) {
                         real_addr = addr;
                     }
 
@@ -100,10 +100,10 @@ public class DnsVpnService extends VpnService implements ValueConstants{
                     Builder vpn = new Builder();
                     vpn.setSession("DnsVpnService")
                             .addAddress(real_addr, 24);
-                    if (!dns1.equals("")) {
+                    if (!"".equals(dns1)) {
                         vpn.addDnsServer(dns1);
                     }
-                    if (!dns2.equals("")) {
+                    if (!"".equals(dns2)) {
                         vpn.addDnsServer(dns2);
                     }
                     fd = vpn.establish();


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1132 - “Strings literals should be placed on the left side when checking for equality”. 

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1132

Please let me know if you have any questions.
Ayman Abdelghany.
